### PR TITLE
Fix stored-sessions listbox selection jumping to Default Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ KiTTY is the full KiTTY feature set forward-ported onto a modern, security-patch
 known limitations see [KNOWN-ISSUES.md](KNOWN-ISSUES.md); for the full feature list
 see [FEATURES.md](FEATURES.md).
 
+## 0.84.1.38-beta — Unreleased
+
+- **Saved-session listbox selection fixed.** Typing a saved-session name that sorts
+  before "Default Settings" no longer highlights the default entry, and saving a
+  session keeps the correct selection after the list refreshes.
+
 ## 0.84.1.37-beta — 2026-06-27
 - **Saved session passwords now work for auto-login and WinSCP.** When a session
   was launched, KiTTY passed the stored password from the launcher to the terminal

--- a/config.c
+++ b/config.c
@@ -860,6 +860,13 @@ static void sessionsaver_handler(dlgcontrol *ctrl, dlgparam *dlg,
             if (top == ssd->sesslist.nsessions) {
                 top -= 1;
             }
+            /* KiTTY: "Default Settings" is forced to index 0, so a real
+             * session name that sorts before it lands the binary search on 0.
+             * Move the highlight to the first real stored session instead. */
+            if (top == 0 && ssd->sesslist.nsessions > 1 &&
+                ssd->savedsession[0] &&
+                strcmp(ssd->savedsession, "Default Settings") != 0)
+                top = 1;
             dlg_listbox_select(ssd->listbox, dlg, top);
         }
     } else if (event == EVENT_ACTION) {

--- a/kitty/kitty_config.c
+++ b/kitty/kitty_config.c
@@ -1144,6 +1144,13 @@ static void sessionsaver_handler(dlgcontrol *ctrl, dlgparam *dlg,
             if (top == ssd->sesslist.nsessions) {
                 top -= 1;
             }
+            /* KiTTY: "Default Settings" is forced to index 0, so a real
+             * session name that sorts before it lands the binary search on 0.
+             * Move the highlight to the first real stored session instead. */
+            if (top == 0 && ssd->sesslist.nsessions > 1 &&
+                ssd->savedsession[0] &&
+                strcmp(ssd->savedsession, "Default Settings") != 0)
+                top = 1;
             dlg_listbox_select(ssd->listbox, dlg, top);
         }
 #ifdef MOD_PERSO
@@ -1211,19 +1218,13 @@ static void sessionsaver_handler(dlgcontrol *ctrl, dlgparam *dlg,
             get_sesslist(&ssd->sesslist, false);
             get_sesslist(&ssd->sesslist, true);
             dlg_refresh(ssd->editbox, dlg);
+            /* KiTTY: remember the just-saved session so the listbox refresh
+             * auto-selects it (with the correct visible index, even when a
+             * folder filter is active). Skip the default settings pseudo-session. */
+            if (ssd->savedsession && ssd->savedsession[0] &&
+                strcmp(ssd->savedsession, "Default Settings") != 0)
+                kitty_set_last_session(ssd->savedsession);
             dlg_refresh(ssd->listbox, dlg);
-            /* KiTTY: keep the just-saved session selected (the refresh above
-             * otherwise leaves the list with nothing highlighted). */
-            {
-                const char *want = (ssd->savedsession && ssd->savedsession[0])
-                                   ? ssd->savedsession : "Default Settings";
-                int j;
-                for (j = 0; j < ssd->sesslist.nsessions; j++)
-                    if (!strcmp(ssd->sesslist.sessions[j], want)) {
-                        dlg_listbox_select(ssd->listbox, dlg, j);
-                        break;
-                    }
-            }
         } else if (!ssd->midsession &&
                    ssd->delbutton && ctrl == ssd->delbutton) {
             int i = dlg_listbox_index(ssd->listbox, dlg);


### PR DESCRIPTION
**What does this PR do?**
The editbox type-ahead binary search treated 'Default Settings' (forced at index 0) as part of the sorted list, so any session name lexicographically before it made the highlight jump to Default Settings. Fix by moving the selection to the first real session when the search lands on index 0.

Also fix the Save button's re-selection logic to use the correct visible listbox index (it previously used the raw session index, which is wrong when a folder filter is active). Remember the saved session as the last session so the listbox refresh auto-selects it.

Apply the same binary-search fix in config.c for upstream parity.

**Related issue(s):**
None

**Checklist**
- [x] Builds clean (MinGW cross-compile; see PORTING.md)
- [x] KiTTY-specific code is guarded/named so it stays mergeable against PuTTY upstream
- [x] Docs updated if behaviour changed (FEATURES.md / CHANGELOG.md / KNOWN-ISSUES.md)
- [x] No secrets, credentials, or local paths committed
