### PR TITLE
Feature/window title placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ see [FEATURES.md](FEATURES.md).
 
 ## 0.84.1.39-beta — 2026-06-30
 
+- **Window title placeholders.** The **Window Title** setting now expands dynamic
+  placeholders so the title reflects the active connection: `%%h` (hostname),
+  `%%s` (saved session name), `%%u` (username), `%%p` (port), `%%P` (protocol),
+  `%%f` (folder), `%%l` (forwarded local ports), and `%%d` (forwarded dynamic
+  ports). See [`docs/window-title-placeholders.md`](docs/window-title-placeholders.md).
 - **Data-integrity fix: legacy (old-KiTTY) passwords now decrypt correctly.**
   0.84.1.38's "auto-decrypt old 9bis-hive passwords on load" applied an extra
   MASKPASS step that **corrupted** them — a migrated session got a wrong password,

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -46,6 +46,7 @@ one is available.
   - [Word navigation modifier](#word-navigation-modifier)
   - [Quick start of a duplicate session](#quick-start-of-a-duplicate-session)
   - [Background image](#background-image)
+  - [Window title placeholders](#window-title-placeholders)
 - **Other features**
   - [Automatic saving](#automatic-saving)
   - [pscp.exe and WinSCP integration](#pscpexe-and-winscp-integration)
@@ -349,6 +350,26 @@ KiTTY lets you instantly open a second window that inherits all of the current s
 (no screenshot)
 
 ### Background image
+
+
+### Window title placeholders
+
+KiTTY can expand dynamic placeholders in the **Window Title** setting so the title reflects the active connection.
+
+**How to use:** Enter a title string such as `%%h - %%s` in the session's **Window Title** field. The available placeholders are:
+
+| Placeholder | Value shown in the window title |
+|---|---|
+| `%%h` | Hostname (falls back to the configured host) |
+| `%%s` | Saved session name |
+| `%%u` | Username |
+| `%%p` | Port number |
+| `%%P` | Protocol display name (e.g. `SSH`) |
+| `%%f` | Folder name the session belongs to |
+| `%%l` | Forwarded local ports (blank if none configured) |
+| `%%d` | Forwarded dynamic (SOCKS) ports (blank if none configured) |
+
+For full details and examples, see [`docs/window-title-placeholders.md`](docs/window-title-placeholders.md).
 
 KiTTY can display a picture behind your terminal text, giving each session window a custom backdrop. It supports BMP and JPEG images, and you can adjust how strongly the image shows through with an opacity setting or rotate through several pictures as a slideshow. This feature grows out of the covidimus patch integrated into KiTTY.
 

--- a/docs/window-title-placeholders.md
+++ b/docs/window-title-placeholders.md
@@ -1,0 +1,52 @@
+---
+title: KiTTY Window Title Placeholders
+---
+
+# KiTTY Window Title Placeholders
+
+KiTTY can expand dynamic placeholders in the **Window Title** setting so that the
+title reflects the active connection. To use a placeholder, type the two-character
+sequence shown below in the **Window Title** field of a saved session.
+
+## Supported placeholders
+
+| Placeholder | Value shown in the window title |
+|-------------|---------------------------------|
+| `%%h` | Hostname (falls back to the configured host if no hostname is available) |
+| `%%s` | Saved session name |
+| `%%u` | Username configured for the session |
+| `%%p` | Port number |
+| `%%P` | Protocol display name (e.g. `SSH`) |
+| `%%f` | Folder name the saved session belongs to |
+| `%%l` | List of forwarded local ports (blank if none are configured) |
+| `%%d` | List of forwarded dynamic (SOCKS) ports (blank if none are configured) |
+
+Any other `%%X` sequence is treated as a literal `%X`.
+
+## Example
+
+Setting the window title to:
+
+```text
+%%h - %%s
+```
+
+produces a title like:
+
+```text
+oakleaf.csup.uk - my-session
+```
+
+A longer example that shows all available values:
+
+```text
+host=%%h | sess=%%s | user=%%u | port=%%p | proto=%%P | folder=%%f | local=%%l | dynamic=%%d
+```
+
+## Notes
+
+* Placeholders are evaluated each time the window title is set up, including when
+  the title is restored by the **Protect** menu.
+* `%%s` is populated only when a saved session is loaded. If a host is entered
+  directly on the command line without loading a saved session, the session name
+  placeholder will be blank.

--- a/kitty/kitty.c
+++ b/kitty/kitty.c
@@ -1829,6 +1829,113 @@ int ResizeWinList( HWND hwnd, int width, int height ) {
 	return NbWindows ;
 }
 
+#ifdef MOD_PERSO
+/* KiTTY: expand window-title placeholders.
+ *   %%h - hostname (falls back to the configured host)
+ *   %%s - saved session name
+ *   %%u - username
+ *   %%p - port number
+ *   %%P - protocol display name (title case)
+ *   %%f - folder name
+ *   %%l - forwarded local ports list
+ *   %%d - forwarded dynamic ports list
+ *   %%X (unknown) - collapse to a single '%', preserving the literal text
+ */
+char *kitty_expand_wintitle(const char *title, const char *hostname, Conf *conf)
+{
+    strbuf *sb = strbuf_new();
+    const char *p = title;
+    while (*p) {
+        if (p[0] == '%' && p[1] == '%') {
+            const char *val = NULL;
+            char portbuf[32];
+            strbuf *list = NULL;
+            char code = p[2];
+
+            switch (code) {
+              case 'h':
+                val = hostname;
+                if (!val || !*val)
+                    val = conf_get_str(conf, CONF_host);
+                if (!val)
+                    val = "";
+                break;
+              case 's':
+                val = conf_get_str(conf, CONF_sessionname);
+                if (!val)
+                    val = "";
+                break;
+              case 'u':
+                val = conf_get_str_ambi(conf, CONF_username, NULL);
+                if (!val)
+                    val = "";
+                break;
+              case 'f':
+                val = conf_get_str(conf, CONF_folder);
+                if (!val)
+                    val = "";
+                break;
+              case 'p':
+                sprintf(portbuf, "%d", conf_get_int(conf, CONF_port));
+                val = portbuf;
+                break;
+              case 'P': {
+                const struct BackendVtable *vt =
+                    backend_vt_from_proto(conf_get_int(conf, CONF_protocol));
+                val = vt ? vt->displayname_tc : "";
+                break;
+              }
+              case 'l':
+              case 'd': {
+                char *key, *valfwd;
+                list = strbuf_new();
+                for (valfwd = conf_get_str_strs(conf, CONF_portfwd, NULL, &key);
+                     valfwd != NULL;
+                     valfwd = conf_get_str_strs(conf, CONF_portfwd, key, &key)) {
+                    const char *k = key;
+                    if (k[0] == ' ')
+                        k++;
+                    if ((code == 'l' && (k[0] == 'L' || k[0] == 'R') &&
+                         strcmp(valfwd, "D") != 0) ||
+                        (code == 'd' && k[0] == 'L' &&
+                         !strcmp(valfwd, "D"))) {
+                        const char *port = k + 1;
+                        if (list->len > 0)
+                            put_fmt(list, ", %s", port);
+                        else
+                            put_fmt(list, "%s", port);
+                    }
+                }
+                val = list->s;
+                break;
+              }
+              default:
+                val = NULL;
+                break;
+            }
+
+            if (val) {
+                put_data(sb, val, strlen(val));
+                p += 3;
+                if (list)
+                    strbuf_free(list);
+            } else {
+                put_byte(sb, '%');
+                p += 2;
+            }
+        } else {
+            put_byte(sb, *p);
+            p++;
+        }
+    }
+    {
+        char *result = dupstr(sb->s);
+        strbuf_free(sb);
+        return result;
+    }
+}
+#endif
+
 void set_title( TermWin *tw, const char *title ) { return win_set_title(tw,title,CP_ACP) ; } // Disparue avec la version 0.71
 void ManageProtect( HWND hwnd, TermWin *tw, char * title ) {
 	HMENU m ;

--- a/kitty/kitty.h
+++ b/kitty/kitty.h
@@ -68,6 +68,9 @@ void SetCapsLockFlag( const int flag ) ;
 int GetTitleBarFlag(void) ;
 void SetTitleBarFlag( const int flag ) ;
 
+// KiTTY: expand window-title placeholders (%%h, %%s, %%u, %%p, %%P, %%f, %%l, %%d)
+char *kitty_expand_wintitle(const char *title, const char *hostname, Conf *conf) ;
+
 // Flag pour passer en mode visualiseur d'images
 // extern int ImageViewerFlag ;
 int GetImageViewerFlag(void) ;

--- a/kitty/kitty_bridge.c
+++ b/kitty/kitty_bridge.c
@@ -174,7 +174,10 @@ void kitty_font_resize(Terminal *term, Conf *conf, int dec) {
 
 void kitty_protect(HWND hwnd, TermWin *tw, Conf *conf) {
     /* ManageProtect only reads title (passes to set_title); cast is safe */
-    ManageProtect(hwnd, tw, (char*)conf_get_str(conf, CONF_wintitle));
+    char *title = kitty_expand_wintitle(conf_get_str(conf, CONF_wintitle),
+                                        conf_get_str(conf, CONF_host), conf);
+    ManageProtect(hwnd, tw, title);
+    sfree(title);
 }
 void kitty_print(HWND hwnd) { ManagePrint(hwnd); }
 

--- a/settings.c
+++ b/settings.c
@@ -709,6 +709,14 @@ bool load_settings(const char *section, Conf *conf)
     NETDBG_TS("load_settings: after load_open_settings");
     close_settings_r(sesskey);
 
+    /* KiTTY: remember the real saved session name so placeholders like %%s
+     * can be expanded in the window title. Skip the default settings pseudo
+     * session and non-existent sessions. (This is compiled into the shared
+     * settings library, so it is intentionally not guarded by MOD_PERSO.) */
+    if (exists && section && *section &&
+        strcmp(section, "Default Settings") != 0)
+        conf_set_str(conf, CONF_sessionname, section);
+
     /* KiTTY: do_defaults() loads "Default Settings" with section==NULL at the top
      * of EVERY launch; never push that to the jump list (it isn't a real recent
      * session, and doing so ran the slow Jump List COM rebuild on the startup

--- a/terminal/terminal.c
+++ b/terminal/terminal.c
@@ -12,6 +12,9 @@
 #include <assert.h>
 #include "putty.h"
 #include "terminal.h"
+#ifdef MOD_PERSO
+char *kitty_expand_wintitle(const char *title, const char *hostname, Conf *conf);
+#endif
 #ifdef MOD_FAR2L
 #include "cdecode.h"
 #include "cencode.h"
@@ -1777,7 +1780,11 @@ void term_reconfig(Terminal *term, Conf *conf)
         const char *new_title = conf_get_str(conf, CONF_wintitle);
         if (strcmp(old_title, new_title)) {
             sfree(term->window_title);
+#ifdef MOD_PERSO
+            term->window_title = kitty_expand_wintitle(new_title, NULL, conf);
+#else
             term->window_title = dupstr(new_title);
+#endif
             term->wintitle_codepage = DEFAULT_CODEPAGE;
             term->win_title_pending = true;
             term_schedule_update(term);
@@ -1913,8 +1920,13 @@ void term_setup_window_titles(Terminal *term, const char *title_hostname)
     sfree(term->window_title);
     sfree(term->icon_title);
     if (*conf_title) {
+#ifdef MOD_PERSO
+        term->window_title = kitty_expand_wintitle(conf_title, title_hostname,
+                                                   term->conf);
+#else
         term->window_title = dupstr(conf_title);
-        term->icon_title = dupstr(conf_title);
+#endif
+        term->icon_title = dupstr(term->window_title);
     } else {
         if (title_hostname && *title_hostname)
             term->window_title = dupcat(title_hostname, " - ", appname);


### PR DESCRIPTION
<!-- Thanks for contributing to KiTTY (PuTTY 0.84 fork). -->

**What does this PR do?**

Restores/expands dynamic KiTTY window-title placeholders. The **Window Title** setting now supports:

- `%%h` — hostname
- `%%s` — saved session name
- `%%u` — username
- `%%p` — port number
- `%%P` — protocol display name (e.g. `SSH`)
- `%%f` — session folder name
- `%%l` — forwarded local ports list
- `%%d` — forwarded dynamic (SOCKS) ports list

Implementation:
- New [kitty_expand_wintitle()](cci:1://file:///C:/Users/Jon/CLionProjects/KiTTY/kitty/kitty.c:1831:0-1934:1) in [kitty/kitty.c](cci:7://file:///C:/Users/Jon/CLionProjects/KiTTY/kitty/kitty.c:0:0-0:0) parses the title string.
- [term_setup_window_titles()](cci:1://file:///C:/Users/Jon/CLionProjects/KiTTY/terminal/terminal.c:1909:0-1927:1), the reconfiguration path, and the **Protect** menu restore path all use it.
- [load_settings()](cci:1://file:///C:/Users/Jon/CLionProjects/KiTTY/settings.c:699:0-733:1) stores the real saved-session name in `CONF_sessionname` so `%%s` works. This is done in the shared [settings.c](cci:7://file:///C:/Users/Jon/CLionProjects/KiTTY/settings.c:0:0-0:0) library intentionally, not behind `MOD_PERSO`, so the value is available regardless of which target links the library.

**Related issue(s):**

None opened.

**Checklist**
- [x] Builds clean (MinGW cross-compile; see PORTING.md)
- [x] KiTTY-specific code is guarded/named so it stays mergeable against PuTTY upstream
- [x] Docs updated if behaviour changed (FEATURES.md / CHANGELOG.md / KNOWN-ISSUES.md)
- [x] No secrets, credentials, or local paths committed