### PR TITLE
Fix duplicate keyboard shortcut 'n' in Terminal/Keyboard panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ KiTTY is the full KiTTY feature set forward-ported onto a modern, security-patch
 known limitations see [KNOWN-ISSUES.md](KNOWN-ISSUES.md); for the full feature list
 see [FEATURES.md](FEATURES.md).
 
+## 0.84.1.38-beta — Unreleased
+
+- **Terminal/Keyboard shortcut collision fixed.** The "Word navigation" and
+  "Initial state of numeric keypad" radio-button groups both used the same
+  shortcut (`n`), causing an assertion failure when opening the
+  **Terminal/Keyboard** panel for a loaded session. Word navigation now uses
+  `l` (Left/Right), so the panel opens without a duplicate-shortcut error.
+
 ## 0.84.1.37-beta — 2026-06-27
 - **Saved session passwords now work for auto-login and WinSCP.** When a session
   was launched, KiTTY passed the stored password from the launcher to the terminal

--- a/kitty/kitty_config.c
+++ b/kitty/kitty_config.c
@@ -2692,7 +2692,7 @@ void setup_config_box(struct controlbox *b, bool midsession,
                       I(CONF_sharrow_type),
                       "Ctrl toggles app mode", I(SHARROW_APPLICATION),
                       "xterm-style bitmap", I(SHARROW_BITMAP));
-    ctrl_radiobuttons(s, "Word navigation (Left/Right arrows)", 'n', 3,
+    ctrl_radiobuttons(s, "Word navigation (Left/Right arrows)", 'l', 3,
                       HELPCTX(no_help),
                       conf_radiobutton_handler,
                       I(CONF_word_nav_modifier),


### PR DESCRIPTION
<!-- Thanks for contributing to KiTTY (PuTTY 0.84 fork). -->

**What does this PR do?**

Fixes an assertion failure (`windows/controls.c:1241`) that occurred when opening the **Terminal/Keyboard** panel for a loaded session. The "Word navigation" and "Initial state of numeric keypad" radio-button groups both used the shortcut `n`. This change assigns `l` (Left/Right) to Word navigation, removing the duplicate.

**Related issue(s):**

None reported.

**Checklist**
- [x] Builds clean (MinGW cross-compile; see PORTING.md)
- [x] KiTTY-specific code is guarded/named so it stays mergeable against PuTTY upstream
- [x] Docs updated if behaviour changed (FEATURES.md / CHANGELOG.md / KNOWN-ISSUES.md)
- [x] No secrets, credentials, or local paths committed