### PR TITLE
Enable Ctrl+Arrow word jump via unconditional MOD_KEYMAPPING

### DIFF
--- a/0.76b_My_PuTTY/putty.h
+++ b/0.76b_My_PuTTY/putty.h
@@ -1,6 +1,10 @@
 #ifndef PUTTY_PUTTY_H
 #define PUTTY_PUTTY_H
 
+#ifndef MOD_KEYMAPPING
+#define MOD_KEYMAPPING
+#endif
+
 #include <stddef.h>		       /* for wchar_t */
 #include <limits.h>                    /* for INT_MAX */
 

--- a/0.76b_My_PuTTY/windows/window.c
+++ b/0.76b_My_PuTTY/windows/window.c
@@ -443,7 +443,7 @@ int WINAPI Agent_WinMain(HINSTANCE inst, HINSTANCE prev, LPSTR cmdline, int show
 
 #endif
 #ifdef MOD_WTS
-typedef enum _WTS_VIRTUAL_CLASS { WTSVirtualClientData, WTSVirtualFileHandle } WTS_VIRTUAL_CLASS; 		// WTS_VIRTUAL_CLASS is not definned in file wtsapi32.h !!!
+// typedef enum _WTS_VIRTUAL_CLASS { WTSVirtualClientData, WTSVirtualFileHandle } WTS_VIRTUAL_CLASS;
 #include <wtsapi32.h>
 #endif
 #if (defined MOD_BACKGROUNDIMAGE) && (!defined FLJ)

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -46,6 +46,7 @@
   * [Start Cygwin or cmd.exe into KiTTY](pages/cygtermd.md)
   * [File association](pages/FileAssociation.md)
   * [Other settings](pages/OtherSettings.md)
+  * [Enhanced key mapping](pages/KeyMapping.md)
   ----
   * [Menu key shortcuts definition](pages/MenuShortcuts.md)
   * [New command-line options](pages/CommandLine.md)

--- a/docs/pages/KeyMapping.md
+++ b/docs/pages/KeyMapping.md
@@ -1,0 +1,34 @@
+<div style="text-align: center;"><iframe src="gad.html" frameborder="0" scrolling="no" style="border: 1px solid gray; padding: 0; overflow:hidden; scrolling: no; top:0; left: 0; width: 100%;" onload="this.style.height=(this.contentWindow.document.body.scrollHeight+5)+'px';"></iframe></div>
+## Enhanced Key Mapping
+
+### Ctrl+Arrow Word Jump
+
+KiTTY now supports **Ctrl+Left Arrow** and **Ctrl+Right Arrow** for word-boundary cursor movement in the terminal. This sends the standard xterm-compatible escape sequences so that the remote shell or line discipline can interpret them as word jumps.
+
+| Key combination | Escape sequence sent | Action |
+|----------------|----------------------|--------|
+| **Ctrl+Left**  | `\x1B[1;5D`          | Jump to previous word boundary |
+| **Ctrl+Right** | `\x1B[1;5C`          | Jump to next word boundary     |
+
+These sequences are recognised by most modern shells (bash, zsh, fish) and by any application that uses the **readline** or **libedit** libraries. If your shell does not move by word, ensure your `~/.inputrc` or shell configuration binds the sequences correctly. For example, in **bash**:
+
+```bash
+bind '"\e[1;5C": forward-word'
+bind '"\e[1;5D": backward-word'
+```
+
+### Modifier key support
+
+With **MOD_KEYMAPPING** now unconditionally enabled, KiTTY sends fully-qualified xterm-style modifier sequences for arrow keys and other special keys. This means Shift, Alt and Ctrl combinations are correctly distinguished and passed to the terminal.
+
+| Modifier | Arrow sequence format |
+|----------|-----------------------|
+| Normal   | `\x1B[A` / `\x1B[B` / `\x1B[C` / `\x1B[D` |
+| Shift    | `\x1B[1;2A` ... |
+| Alt      | `\x1B[1;3A` ... |
+| Ctrl     | `\x1B[1;5A` ... |
+| Ctrl+Shift | `\x1B[1;6A` ... |
+| Ctrl+Alt | `\x1B[1;7A` ... |
+| Ctrl+Alt+Shift | `\x1B[1;8A` ... |
+
+This behaviour is automatically active for all builds and does not require any configuration change.


### PR DESCRIPTION
<!-- Thanks for contributing to KiTTY (PuTTY 0.84 fork). -->

**What does this PR do?**

- Always defines `MOD_KEYMAPPING` in [putty.h](cci:7://file:///C:/Users/Jon/CLionProjects/KiTTY/0.76_My_PuTTY/putty.h:0:0-0:0) so that xterm-style modifier key sequences (including Ctrl+Left/Right) are generated regardless of build flags or build system.
- Fixes `WTS_VIRTUAL_CLASS` redeclaration conflict with modern MinGW `wtsapi32.h` by commenting out the manual typedef.
- Adds [docs/pages/KeyMapping.md](cci:7://file:///C:/Users/Jon/CLionProjects/KiTTY/docs/pages/KeyMapping.md:0:0-0:0) documenting the enhanced key mapping and Ctrl+Arrow word-boundary movement.
- Updates [docs/navigation.md](cci:7://file:///C:/Users/Jon/CLionProjects/KiTTY/docs/navigation.md:0:0-0:0) to link the new documentation.

**Related issue(s):**
N/A — this is a build-system compatibility and feature-enablement change.
Just noticed it was missing and its a feature i use a lot

**Checklist**
- [x] Builds clean (MinGW cross-compile; see PORTING.md)
- [x] KiTTY-specific code is guarded/named so it stays mergeable against PuTTY upstream
- [x] Docs updated if behaviour changed (new [docs/pages/KeyMapping.md](cci:7://file:///C:/Users/Jon/CLionProjects/KiTTY/docs/pages/KeyMapping.md:0:0-0:0) + [navigation.md](cci:7://file:///C:/Users/Jon/CLionProjects/KiTTY/docs/navigation.md:0:0-0:0) updated)
- [x] No secrets, credentials, or local paths committed